### PR TITLE
POSIX: Show errormessage if loading a (Mod) .so failed, refs #318

### DIFF
--- a/neo/sys/win32/win_main.cpp
+++ b/neo/sys/win32/win_main.cpp
@@ -600,6 +600,9 @@ uintptr_t Sys_DLL_Load( const char *dllName ) {
 			Sys_DLL_Unload( (uintptr_t)libHandle );
 			return 0;
 		}
+	} else {
+		DWORD e = GetLastError();
+		// TODO
 	}
 	return (uintptr_t)libHandle;
 }


### PR DESCRIPTION
.. but only if the file exists.
It's ok if mods don't have their own DLL/.so, but if they do have one
and loading fails it's interesting why they failed (e.g. no access
rights, 64bit lib with 32bit executable or other way around, missing
symbols due to wrong libc version, ...)

The same should be done for Windows, but that's still TODO.